### PR TITLE
Add ability to use spark reader native implemention

### DIFF
--- a/docs/data_access_layer/configuration_example.md
+++ b/docs/data_access_layer/configuration_example.md
@@ -19,6 +19,7 @@
 | emptyValue | sets the string representation of an empty value | true, default empty string|  |
 | dateFormat  | sets the string that indicates a date format | true, default `yyyy-MM-dd`| |
 | timestampFormat | sets the string that indicates a timestamp format  | true, default `yyyy-MM-dd'T'HH:mm:ss.SSSXXX`| |
+| pathFormat | choose between REGEX path format (ex: s3://bucket//col1=*/col2=A/*) or WILDCARD path format (ex: s3://bucket/*/*A*/internal-*.csv) | true, default `REGEX`| `WILDCARD` |
 
 For other options, please refer to [this doc](https://spark.apache.org/docs/latest/api/scala/org/apache/spark/sql/DataFrameReader.html).
 
@@ -69,6 +70,7 @@ csvWithSchema {
 | dateFormat  | sets the string that indicates a date format | true, default `yyyy-MM-dd`| |
 | timestampFormat | sets the string that indicates a timestamp format  | true, default `yyyy-MM-dd'T'HH:mm:ss.SSSXXX`| |
 | dropFieldIfAllNull | whether to ignore column of all null values or empty array/struct during schema inference  | true, default `false` | |
+| pathFormat | choose between REGEX path format (ex: s3://bucket//col1=*/col2=A/*) or WILDCARD path format (ex: s3://bucket/*/*A*/internal-*.csv) | true, default `REGEX`| `WILDCARD` |
 
 For other options, please refer to [this doc](https://spark.apache.org/docs/latest/api/scala/org/apache/spark/sql/DataFrameReader.html).
 
@@ -91,6 +93,7 @@ json {
 | path | directory of parquet files |   | |
 | saveMode |  |  true, default `ErrorIfExists` | `Append` |
 | filenamePattern | Regex of the names of file to be read. When `filenamePattern` is set, then this connector can only be used for reading data | true, default empty | `(file)(.*)(\\.csv)` |
+| pathFormat | choose between REGEX path format (ex: s3://bucket//col1=*/col2=A/*) or WILDCARD path format (ex: s3://bucket/*/*A*/internal-*.csv) | true, default `REGEX`| `WILDCARD` |
 
 ### Example
 

--- a/docs/data_access_layer/configuration_example.md
+++ b/docs/data_access_layer/configuration_example.md
@@ -19,7 +19,7 @@
 | emptyValue | sets the string representation of an empty value | true, default empty string|  |
 | dateFormat  | sets the string that indicates a date format | true, default `yyyy-MM-dd`| |
 | timestampFormat | sets the string that indicates a timestamp format  | true, default `yyyy-MM-dd'T'HH:mm:ss.SSSXXX`| |
-| pathFormat | choose between REGEX path format (ex: s3://bucket//col1=*/col2=A/*) or WILDCARD path format (ex: s3://bucket/*/*A*/internal-*.csv) | true, default `REGEX`| `WILDCARD` |
+| pathFormat | choose between REGEX path format (ex: `^s3:\/\/bucket\/\/col1=B\/col2=([A-C])$`) or WILDCARD path format (ex: `s3://bucket/*/*A*/internal-*.csv`) | true, default `REGEX`| `WILDCARD` |
 
 For other options, please refer to [this doc](https://spark.apache.org/docs/latest/api/scala/org/apache/spark/sql/DataFrameReader.html).
 
@@ -70,7 +70,7 @@ csvWithSchema {
 | dateFormat  | sets the string that indicates a date format | true, default `yyyy-MM-dd`| |
 | timestampFormat | sets the string that indicates a timestamp format  | true, default `yyyy-MM-dd'T'HH:mm:ss.SSSXXX`| |
 | dropFieldIfAllNull | whether to ignore column of all null values or empty array/struct during schema inference  | true, default `false` | |
-| pathFormat | choose between REGEX path format (ex: s3://bucket//col1=*/col2=A/*) or WILDCARD path format (ex: s3://bucket/*/*A*/internal-*.csv) | true, default `REGEX`| `WILDCARD` |
+| pathFormat | choose between REGEX path format (ex: `^s3:\/\/bucket\/\/col1=B\/col2=([A-C])$`) or WILDCARD path format (ex: `s3://bucket/*/*A*/internal-*.csv`) | true, default `REGEX`| `WILDCARD` |
 
 For other options, please refer to [this doc](https://spark.apache.org/docs/latest/api/scala/org/apache/spark/sql/DataFrameReader.html).
 
@@ -93,7 +93,7 @@ json {
 | path | directory of parquet files |   | |
 | saveMode |  |  true, default `ErrorIfExists` | `Append` |
 | filenamePattern | Regex of the names of file to be read. When `filenamePattern` is set, then this connector can only be used for reading data | true, default empty | `(file)(.*)(\\.csv)` |
-| pathFormat | choose between REGEX path format (ex: s3://bucket//col1=*/col2=A/*) or WILDCARD path format (ex: s3://bucket/*/*A*/internal-*.csv) | true, default `REGEX`| `WILDCARD` |
+| pathFormat | choose between REGEX path format (ex: `^s3:\/\/bucket\/\/col1=B\/col2=([A-C])$`) or WILDCARD path format (ex: `s3://bucket/*/*A*/internal-*.csv`) | true, default `REGEX`| `WILDCARD` |
 
 ### Example
 

--- a/src/main/java/io/github/setl/enums/PathFormat.java
+++ b/src/main/java/io/github/setl/enums/PathFormat.java
@@ -1,0 +1,6 @@
+package io.github.setl.enums;
+
+public enum PathFormat {
+    WILDCARD,
+    REGEX;
+}

--- a/src/main/scala/io/github/setl/config/FileConnectorConf.scala
+++ b/src/main/scala/io/github/setl/config/FileConnectorConf.scala
@@ -1,7 +1,7 @@
 package io.github.setl.config
 
 import io.github.setl.annotation.InterfaceStability
-import io.github.setl.enums.Storage
+import io.github.setl.enums.{PathFormat, Storage}
 import io.github.setl.exception.ConfException
 import io.github.setl.annotation.InterfaceStability.Evolving
 import org.apache.spark.sql.SaveMode
@@ -11,7 +11,7 @@ class FileConnectorConf extends ConnectorConf {
 
   private[this] val defaultEncoding: String = "UTF-8"
   private[this] val defaultSaveMode: String = SaveMode.ErrorIfExists.toString
-  private[this] val defaultNative: String = "false"
+  private[this] val defaultPathFormat: String = PathFormat.REGEX.toString
 
   def setStorage(storage: String): this.type = set("storage", storage.toUpperCase)
 
@@ -25,7 +25,7 @@ class FileConnectorConf extends ConnectorConf {
 
   def setPath(path: String): this.type = set("path", path)
 
-  def setNative(native: String): this.type = set("native", native)
+  def setPathFormat(pathFormat: PathFormat): this.type = set("pathFormat", pathFormat.toString)
 
   def setS3CredentialsProvider(value: String): this.type = set("fs.s3a.aws.credentials.provider", value)
 
@@ -39,7 +39,7 @@ class FileConnectorConf extends ConnectorConf {
 
   def getSaveMode: SaveMode = SaveMode.valueOf(get("saveMode", defaultSaveMode))
 
-  def getNative: String = get("native", defaultNative)
+  def getPathFormat: String = get("pathFormat", defaultPathFormat)
 
   def getStorage: Storage = get("storage") match {
     case Some(storage) => Storage.valueOf(storage)

--- a/src/main/scala/io/github/setl/config/FileConnectorConf.scala
+++ b/src/main/scala/io/github/setl/config/FileConnectorConf.scala
@@ -11,6 +11,7 @@ class FileConnectorConf extends ConnectorConf {
 
   private[this] val defaultEncoding: String = "UTF-8"
   private[this] val defaultSaveMode: String = SaveMode.ErrorIfExists.toString
+  private[this] val defaultNative: String = "false"
 
   def setStorage(storage: String): this.type = set("storage", storage.toUpperCase)
 
@@ -24,6 +25,8 @@ class FileConnectorConf extends ConnectorConf {
 
   def setPath(path: String): this.type = set("path", path)
 
+  def setNative(native: String): this.type = set("native", native)
+
   def setS3CredentialsProvider(value: String): this.type = set("fs.s3a.aws.credentials.provider", value)
 
   def setS3AccessKey(value: String): this.type = set("fs.s3a.access.key", value)
@@ -35,6 +38,8 @@ class FileConnectorConf extends ConnectorConf {
   def getEncoding: String = get("encoding", defaultEncoding)
 
   def getSaveMode: SaveMode = SaveMode.valueOf(get("saveMode", defaultSaveMode))
+
+  def getNative: String = get("native", defaultNative)
 
   def getStorage: Storage = get("storage") match {
     case Some(storage) => Storage.valueOf(storage)

--- a/src/main/scala/io/github/setl/storage/connector/CSVConnector.scala
+++ b/src/main/scala/io/github/setl/storage/connector/CSVConnector.scala
@@ -2,7 +2,7 @@ package io.github.setl.storage.connector
 
 import io.github.setl.annotation.InterfaceStability
 import io.github.setl.config.{Conf, FileConnectorConf}
-import io.github.setl.enums.Storage
+import io.github.setl.enums.{PathFormat, Storage}
 import io.github.setl.util.TypesafeConfigUtils
 import com.typesafe.config.Config
 import org.apache.spark.sql._
@@ -91,13 +91,13 @@ class CSVConnector(override val options: FileConnectorConf) extends FileConnecto
 
   def this(config: Conf) = this(config.toMap)
 
-  def this(path: String, inferSchema: String, delimiter: String, header: String, saveMode: SaveMode, native: String = "false") =
+  def this(path: String, inferSchema: String, delimiter: String, header: String, saveMode: SaveMode, pathFormat: PathFormat = PathFormat.REGEX) =
     this(Map[String, String](
       "path" -> path,
       "inferSchema" -> inferSchema,
       "header" -> header,
       "saveMode" -> saveMode.toString,
-      "native" -> native
+      "pathFormat" -> pathFormat.toString
     ))
 
   override val storage: Storage = Storage.CSV

--- a/src/main/scala/io/github/setl/storage/connector/CSVConnector.scala
+++ b/src/main/scala/io/github/setl/storage/connector/CSVConnector.scala
@@ -91,12 +91,13 @@ class CSVConnector(override val options: FileConnectorConf) extends FileConnecto
 
   def this(config: Conf) = this(config.toMap)
 
-  def this(path: String, inferSchema: String, delimiter: String, header: String, saveMode: SaveMode) =
+  def this(path: String, inferSchema: String, delimiter: String, header: String, saveMode: SaveMode, native: String = "false") =
     this(Map[String, String](
       "path" -> path,
       "inferSchema" -> inferSchema,
       "header" -> header,
-      "saveMode" -> saveMode.toString
+      "saveMode" -> saveMode.toString,
+      "native" -> native
     ))
 
   override val storage: Storage = Storage.CSV

--- a/src/main/scala/io/github/setl/storage/connector/FileConnector.scala
+++ b/src/main/scala/io/github/setl/storage/connector/FileConnector.scala
@@ -479,11 +479,11 @@ abstract class FileConnector(val options: FileConnectorConf) extends Connector w
    */
   @throws[java.io.FileNotFoundException](s"$absolutePath doesn't exist")
   @throws[org.apache.spark.sql.AnalysisException](s"$absolutePath doesn't exist")
-  override def read(native: Boolean = false): DataFrame = {
+  override def read(): DataFrame = {
     logDebug(s"Reading ${options.getStorage.toString} file in: '${absolutePath.toString}'")
     this.setJobDescription(s"Read file(s) from '${absolutePath.toString}'")
 
-    val df = if (native) {
+    val df = if (options.getNative.equals("true")) {
       reader
         .format(options.getStorage.toString.toLowerCase())
         .load(options.getPath)

--- a/src/main/scala/io/github/setl/storage/connector/FileConnector.scala
+++ b/src/main/scala/io/github/setl/storage/connector/FileConnector.scala
@@ -483,12 +483,12 @@ abstract class FileConnector(val options: FileConnectorConf) extends Connector w
     logDebug(s"Reading ${options.getStorage.toString} file in: '${absolutePath.toString}'")
     this.setJobDescription(s"Read file(s) from '${absolutePath.toString}'")
 
-    val df = PathFormat.valueOf(options.getPathFormat) match {
-      case PathFormat.WILDCARD =>
+    val df = options.getPathFormat match {
+      case value if value == PathFormat.WILDCARD.toString =>
         reader
           .format(options.getStorage.toString.toLowerCase())
           .load(options.getPath)
-      case PathFormat.REGEX =>
+      case value if value == PathFormat.REGEX.toString =>
         reader
           .option("basePath", basePath.toString)
           .format(options.getStorage.toString.toLowerCase())

--- a/src/main/scala/io/github/setl/storage/connector/FileConnector.scala
+++ b/src/main/scala/io/github/setl/storage/connector/FileConnector.scala
@@ -494,7 +494,7 @@ abstract class FileConnector(val options: FileConnectorConf) extends Connector w
           .format(options.getStorage.toString.toLowerCase())
           .load(listFilesToLoad(false): _*)
       case _ =>
-        throw new UnsupportedOperationException(s"Unsupported path format ${options.getPath}.")
+        throw new UnsupportedOperationException(s"Unsupported path format ${options.getPathFormat}.")
     }
 
     if (dropUserDefinedSuffix & df.columns.contains(UDSKey)) {

--- a/src/main/scala/io/github/setl/storage/connector/FileConnector.scala
+++ b/src/main/scala/io/github/setl/storage/connector/FileConnector.scala
@@ -486,7 +486,7 @@ abstract class FileConnector(val options: FileConnectorConf) extends Connector w
     val df = if (native) {
       reader
         .format(options.getStorage.toString.toLowerCase())
-        .path(listFilesToLoad(false): _*)
+        .load(options.getPath)
     } else {
       reader
         .option("basePath", basePath.toString)

--- a/src/test/scala/io/github/setl/config/FileConnectorConfSuite.scala
+++ b/src/test/scala/io/github/setl/config/FileConnectorConfSuite.scala
@@ -1,6 +1,6 @@
 package io.github.setl.config
 
-import io.github.setl.enums.Storage
+import io.github.setl.enums.{PathFormat, Storage}
 import io.github.setl.exception.ConfException
 import org.apache.spark.sql.SaveMode
 import org.scalatest.funsuite.AnyFunSuite
@@ -31,9 +31,9 @@ class FileConnectorConfSuite extends AnyFunSuite {
     conf.setPath("path")
     assert(conf.get("path").get === "path")
 
-    assert(conf.get("native") === None)
-    conf.setNative("true")
-    assert(conf.get("native").get === "true")
+    assert(conf.get("pathFormat") === None)
+    conf.setPathFormat(PathFormat.WILDCARD)
+    assert(conf.get("pathFormat").get === "WILDCARD")
 
     assert(conf.get("credentialsProvider") === None)
     conf.setS3CredentialsProvider("credentialsProvider")
@@ -57,7 +57,7 @@ class FileConnectorConfSuite extends AnyFunSuite {
     assert(conf.getSaveMode === SaveMode.Overwrite)
     assert(conf.getStorage === Storage.EXCEL)
     assert(conf.getPath === "path")
-    assert(conf.getNative === "true")
+    assert(conf.getPathFormat === "WILDCARD")
     assert(conf.getSchema === None)
     assert(conf.getS3CredentialsProvider === Some("credentialsProvider"))
     assert(conf.getS3AccessKey === Some("accessKey"))

--- a/src/test/scala/io/github/setl/config/FileConnectorConfSuite.scala
+++ b/src/test/scala/io/github/setl/config/FileConnectorConfSuite.scala
@@ -31,6 +31,10 @@ class FileConnectorConfSuite extends AnyFunSuite {
     conf.setPath("path")
     assert(conf.get("path").get === "path")
 
+    assert(conf.get("native") === None)
+    conf.setNative("true")
+    assert(conf.get("native").get === "true")
+
     assert(conf.get("credentialsProvider") === None)
     conf.setS3CredentialsProvider("credentialsProvider")
     assert(conf.get("fs.s3a.aws.credentials.provider").get === "credentialsProvider")
@@ -53,6 +57,7 @@ class FileConnectorConfSuite extends AnyFunSuite {
     assert(conf.getSaveMode === SaveMode.Overwrite)
     assert(conf.getStorage === Storage.EXCEL)
     assert(conf.getPath === "path")
+    assert(conf.getNative === "true")
     assert(conf.getSchema === None)
     assert(conf.getS3CredentialsProvider === Some("credentialsProvider"))
     assert(conf.getS3AccessKey === Some("accessKey"))

--- a/src/test/scala/io/github/setl/storage/connector/FileConnectorSuite.scala
+++ b/src/test/scala/io/github/setl/storage/connector/FileConnectorSuite.scala
@@ -199,6 +199,24 @@ class FileConnectorSuite extends AnyFunSuite with Matchers {
     new CSVConnector(path, "true", ",", "true", SaveMode.Overwrite).drop()
   }
 
+  test("FileConnector should throw exception with unsupported pathFormat option") {
+    val spark: SparkSession = new SparkSessionBuilder().setEnv("local").build().get()
+
+    import spark.implicits._
+    val options = Map[String, String](
+      "path" -> "src/test/resources",
+      "pathFormat" -> "TEST"
+    )
+    val fileConnectorConf = new FileConnectorConf()
+    fileConnectorConf.set(options)
+
+    val fileConnector = new FileConnector(fileConnectorConf) {
+      override val storage: Storage = Storage.CSV
+    }
+
+    assertThrows[UnsupportedOperationException](fileConnector.read())
+  }
+
   test("File connector functionality") {
     val spark: SparkSession = new SparkSessionBuilder().setEnv("local").build().get()
 

--- a/src/test/scala/io/github/setl/storage/connector/FileConnectorSuite.scala
+++ b/src/test/scala/io/github/setl/storage/connector/FileConnectorSuite.scala
@@ -129,7 +129,7 @@ class FileConnectorSuite extends AnyFunSuite with Matchers {
     connectorRead.collect() should contain theSameElementsAs sparkRead.collect()
 
     // remove test files
-    new ParquetConnector(path, SaveMode.Overwrite).delete()
+    new ParquetConnector(path, SaveMode.Overwrite).drop()
   }
 
   test("File connector should handle wildcard file path (csv)") {
@@ -163,7 +163,7 @@ class FileConnectorSuite extends AnyFunSuite with Matchers {
     connectorRead.collect() should contain theSameElementsAs sparkRead.collect()
 
     // remove test files
-    new CSVConnector(path, "true", ",", "true", SaveMode.Overwrite).delete()
+    new CSVConnector(path, "true", ",", "true", SaveMode.Overwrite).drop()
   }
 
 
@@ -196,7 +196,7 @@ class FileConnectorSuite extends AnyFunSuite with Matchers {
     connectorRead.collect() should contain theSameElementsAs sparkRead.collect()
 
     // remove test files
-    new CSVConnector(path, "true", ",", "true", SaveMode.Overwrite).delete()
+    new CSVConnector(path, "true", ",", "true", SaveMode.Overwrite).drop()
   }
 
   test("File connector functionality") {
@@ -235,7 +235,7 @@ class FileConnectorSuite extends AnyFunSuite with Matchers {
     connector.write(dff.toDF, None)
     assertThrows[IllegalArgumentException](connector.write(dff.toDF, Some("test")))
     assertThrows[IllegalArgumentException](connector.setSuffix(Some("test")))
-    connector.delete()
+    connector.drop()
   }
 
   test("FileConnector should handle parallel write") {
@@ -289,7 +289,7 @@ class FileConnectorSuite extends AnyFunSuite with Matchers {
       case other: Exception => throw other
     }
 
-    connector.delete()
+    connector.drop()
   }
 
   test("FileConnector should handle base path correctly") {

--- a/src/test/scala/io/github/setl/storage/connector/FileConnectorSuite.scala
+++ b/src/test/scala/io/github/setl/storage/connector/FileConnectorSuite.scala
@@ -1,7 +1,7 @@
 package io.github.setl.storage.connector
 
 import io.github.setl.config.FileConnectorConf
-import io.github.setl.enums.Storage
+import io.github.setl.enums.{PathFormat, Storage}
 import io.github.setl.{SparkSessionBuilder, TestObject}
 import org.apache.hadoop.fs.{LocalFileSystem, Path}
 import org.apache.spark.sql.{DataFrame, Dataset, SaveMode, SparkSession}
@@ -167,7 +167,7 @@ class FileConnectorSuite extends AnyFunSuite with Matchers {
   }
 
 
-  test("File connector should handle spark native reader") {
+  test("File connector should handle spark native path format") {
     val spark: SparkSession = new SparkSessionBuilder().setEnv("local").build().get()
     val path = "src/test/resources/fileconnector_test_dir_csv"
     import spark.implicits._
@@ -184,7 +184,7 @@ class FileConnectorSuite extends AnyFunSuite with Matchers {
 
     df.write.mode(SaveMode.Overwrite).partitionBy("col1", "col2").option("header", "true").csv(path)
 
-    val connector = new CSVConnector(s"$path/col1=*/col2=A/*.csv", "true", ",", "true", SaveMode.Overwrite, "true")
+    val connector = new CSVConnector(s"$path/col1=*/col2=A/*.csv", "true", ",", "true", SaveMode.Overwrite, PathFormat.WILDCARD)
     val connectorRead = connector.read()
     connectorRead.show()
 


### PR DESCRIPTION
Current FileConnector use a customized way of reading file by lister all paths and passing it to Spark.
It is useful but still we need to make it possible for developers to use the "native" way provided by Spark.

This update add an optional flag to read function to make it possible to choose between native reader in spark and the customized one by Setl.

Another way of implementing this is by adding a new parameter to FileConnectorConf.

**EDIT**
I made a change to add a new option in FileConnectorConf