### PR TITLE
[SETL-240] configurable stage parallelism level

### DIFF
--- a/src/main/scala/io/github/setl/util/SparkUtils.scala
+++ b/src/main/scala/io/github/setl/util/SparkUtils.scala
@@ -22,6 +22,11 @@ private[setl] object SparkUtils {
     thisVer.take(3).toInt >= targetVer.take(3).toInt
   }
 
+  def checkScalaVersion(requiredVersion: String): Boolean = {
+    val currentVersion = scala.util.Properties.versionNumberString
+    currentVersion >= requiredVersion
+  }
+
   def withSparkVersion[T](minVersion: String)(fun: Boolean => T): T = {
     try {
       fun(checkSparkVersion(minVersion))

--- a/src/main/scala/io/github/setl/workflow/Stage.scala
+++ b/src/main/scala/io/github/setl/workflow/Stage.scala
@@ -8,12 +8,13 @@ import io.github.setl.transformation.{AbstractFactory, Deliverable, Factory}
 import org.apache.spark.sql.SparkSession
 
 import scala.collection.mutable.ArrayBuffer
+import scala.collection.parallel.ForkJoinTaskSupport
 import scala.collection.parallel.mutable.ParArray
 import scala.reflect.ClassTag
 
 /**
  * A Stage is a collection of independent Factories. All the stages of a pipeline will be executed
- * sequentially at runtime. Within a stage, all factories could be executed in parallel or in sequential order.
+ * sequentially at runtime. Within a stage, factories could be executed in parallel or in sequential order.
  */
 @InterfaceStability.Evolving
 class Stage extends Logging
@@ -27,6 +28,7 @@ class Stage extends Logging
   private[this] var _optimization: Boolean = false
   private[this] var _end: Boolean = true
   private[this] var _parallel: Boolean = true
+  private[this] var _parallelismLevel: Option[Int] = None
   private[this] var _stageId: Int = _
   private[this] var _deliverable: Array[Deliverable[_]] = _
   private[this] val _benchmarkResult: ArrayBuffer[BenchmarkResult] = ArrayBuffer.empty
@@ -65,6 +67,28 @@ class Stage extends Logging
    */
   def parallel(boo: Boolean): this.type = {
     _parallel = boo
+    this
+  }
+
+  /**
+   * Set the parallelism level
+   * @param parallelismLevel Int, parallelism level
+   * @throws IllegalArgumentException will be thrown if the input parallelism level is less or equal than 0
+   * @return this
+   */
+  @throws[IllegalArgumentException]
+  def parallel(parallelismLevel: Int): this.type = {
+    if (parallelismLevel <=0) {
+      throw new IllegalArgumentException("Invalid parallelism level. It must be a positive integer.")
+    }
+
+    if (parallelismLevel != 1) {
+      _parallel = true
+      _parallelismLevel = Some(parallelismLevel)
+    } else {
+      _parallel = false
+    }
+
     this
   }
 
@@ -162,8 +186,17 @@ class Stage extends Logging
     _deliverable = parallelFactories match {
       case Left(par) =>
         logDebug(s"Stage $stageId will be run in parallel mode")
-        par.map(runFactory).toArray
-
+        this._parallelismLevel match {
+          case Some(level) =>
+            val forkJoinPool = new java.util.concurrent.ForkJoinPool(level)
+            par.tasksupport = new ForkJoinTaskSupport(forkJoinPool)
+            logInfo(s"Set the stage parallelism level to $level")
+            val output = par.map(runFactory).toArray
+            forkJoinPool.shutdown()
+            output
+          case _ =>
+            par.map(runFactory).toArray
+        }
       case Right(nonpar) =>
         logDebug(s"Stage $stageId will be run in sequential mode")
         nonpar.map(runFactory)

--- a/src/test/resources/log4j.properties
+++ b/src/test/resources/log4j.properties
@@ -1,8 +1,8 @@
 # Root logger option
 log4j.rootLogger=warn, stdout
 # Captures all logs inside jcdecaux airport package
-log4j.logger.com.jcdecaux=DEBUG, stdout
-log4j.additivity.com.jcdecaux=false
+log4j.logger.io.github.setl=DEBUG, stdout
+log4j.additivity.io.github.setl=false
 # Decrease the verbosity of external libraries logging
 log4j.logger.org.apache=WARN, stdout
 log4j.additivity.org.apache=false

--- a/src/test/scala/io/github/setl/storage/connector/FileConnectorSuite.scala
+++ b/src/test/scala/io/github/setl/storage/connector/FileConnectorSuite.scala
@@ -205,7 +205,8 @@ class FileConnectorSuite extends AnyFunSuite with Matchers {
     import spark.implicits._
     val options = Map[String, String](
       "path" -> "src/test/resources",
-      "pathFormat" -> "TEST"
+      "pathFormat" -> "TEST",
+      "storage" -> "CSV"
     )
     val fileConnectorConf = new FileConnectorConf()
     fileConnectorConf.set(options)

--- a/src/test/scala/io/github/setl/workflow/StageSuite.scala
+++ b/src/test/scala/io/github/setl/workflow/StageSuite.scala
@@ -106,7 +106,7 @@ class StageSuite extends AnyFunSuite {
 
     assert(connector.read().count() === 2, "Output should be persisted")
 
-    connector.delete()
+    connector.drop()
   }
 
   test("Getters of stage") {
@@ -139,7 +139,29 @@ class StageSuite extends AnyFunSuite {
       .addFactory[PersistenceTest](Array(connector))
       .run()
 
-    connector.delete()
+    connector.drop()
+  }
+
+  test("Set stage parallelism") {
+    val spark: SparkSession = new SparkSessionBuilder().setEnv("local").build().get()
+
+    val connectorOptions: Map[String, String] = Map[String, String](
+      "path" -> "src/test/resources/test_csv_persistence",
+      "inferSchema" -> "true",
+      "delimiter" -> "|",
+      "header" -> "true",
+      "saveMode" -> "Overwrite"
+    )
+
+    val connector = new CSVConnector(connectorOptions)
+    val stage = new Stage().writable(true)
+
+    stage
+      .addFactory[PersistenceTest](Array(connector))
+      .parallel(5)
+      .run()
+
+    connector.drop()
   }
 }
 


### PR DESCRIPTION
#240 suggested a controllable stage parallelism level. This can be achieved by adding a new method 
```scala
def parallel(parallelismLevel: Int): this.type
```
in the Stage class.

